### PR TITLE
Fix build with different compiler versions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,8 +11,7 @@ jobs:
           - 9
           - 10
           - 11
-        compiler:
-          - gcc
+          - 12
         build_type:
           - Release
 
@@ -21,7 +20,7 @@ jobs:
       - name: googletests_submodule_init
         run: git submodule update --init
       - name: docker_image_build
-        run: docker build --network=host -t build_filcompare .
+        run: docker build --build-arg GCC_VERSION=${{ matrix.compiler_version }} -t build_filcompare .
       - name: run_build_in_docker
         run: docker run --user $(id -u):$(id -g) -v $PWD:/opt/project build_filcompare
       - name: cmake_format

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:jammy
 
+ARG GCC_VERSION="11"
+
 RUN apt-get update && \
 	apt-get install -y \
 	apt-transport-https \
@@ -16,8 +18,8 @@ RUN apt-get update && \
 	lsb-release \
 	software-properties-common \
 	wget \
-	gcc \
-	g++ \
+	gcc-${GCC_VERSION} \
+	g++-${GCC_VERSION} \
 	cmake \
     clang \
 #    clang-doc \
@@ -33,6 +35,8 @@ RUN apt-get update && \
 #    liblldb \
     python3-clang \
     python3-lldb \
+ && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 10 \
+ && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 10 \
  && pip3 install cpplint && \
 	pip3 install cmake_format && \
 	pip3 install pyyaml \


### PR DESCRIPTION
There was three CI builds on github that supposed to be building with three different compiler versions.

But thre was an exactly the same docker image used for build (with the same gcc-11)