### PR TITLE
Fix compiler warnings settings

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,15 +36,12 @@ jobs:
 
       - name: Clang build
         run: |
-          docker run --user $(id -u):$(id -g) -v $PWD:/opt/project build_filcompare bash -c \
-          "  rm -rfv build                                                                  \
-          && mkdir build                                                                    \
-          && cd build                                                                       \
-          && export CC=/usr/bin/clang                                                       \
-          && export CXX=/usr/bin/clang++                                                    \
-          && cmake -DCMAKE_VERBOSE_MAKEFILE=TRUE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..      \
-          && cmake --build . --parallel                                                     \
-          "
+          docker run \
+            --user $(id -u):$(id -g)                   \
+            -v $PWD:/opt/project                       \
+            -e CC=/usr/bin/clang                       \
+            -e CXX=/usr/bin/clang++                    \
+            build_filcompare
 
       - name: clang-tidy
         run: docker run --rm --user $(id -u):$(id -g) -v $PWD:/opt/project build_filcompare clang-tidy -p build/ -header-filter=.* -extra-arg=-std=c++17 -checks=*,-fuchsia*,-hicpp*,-llvm-header-guard,-llvm-include-order,-google-readability-braces-around-statements,-readability-avoid-const-params-in-decls,-modernize-use-trailing-return-type,-llvmlibc* src/*pp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,23 @@
 project(filcompare LANGUAGES CXX)
 cmake_minimum_required(VERSION 3.10)
+
 # Link this 'library' to set the c++ standard / compile-time options requested
-set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_library(project_options INTERFACE)
+
+# sanitizer options if supported by compiler
+include(cmake/Sanitizers.cmake)
+enable_sanitizers(project_options)
+
+# standard compiler warnings
+include(cmake/CompilerWarnings.cmake)
+set_project_warnings(project_options)
 target_compile_features(project_options INTERFACE cxx_std_17)
+
+# allow for static analysis options
+include(cmake/StaticAnalyzers.cmake)
+
 include_directories(${CMAKE_SOURCE_DIR})
-include_directories(submodules/SQLiteCpp/include)
+
 add_subdirectory(submodules)
 add_subdirectory(src)
 add_subdirectory(tests)
-include(cmake/StaticAnalyzers.cmake)

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,22 @@ CMD echo ${PWD} && \
     g++ --version && \
 	clang --version && \
 	echo ${CXX} && \
-	echo ${CC} && \
-	mkdir build && cd build && \
-	cmake .. && \
-	cmake -D ENABLE_TEST_COVERAGE=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  -DCMAKE_VERBOSE_MAKEFILE=TRUE -DENABLE_SANITIZER_ADDRESS=TRUE . && \
-	cmake --build . -- -j2 && \
-	cd tests && \
+	echo ${CC}     \
+ && rm -rf build && mkdir -vp build               \
+ && cmake                                         \
+      -DCMAKE_BUILD_TYPE=Debug                    \
+      -DWARNINGS_AS_ERRORS=OFF                    \
+      -DCMAKE_VERBOSE_MAKEFILE=TRUE               \
+      -DENABLE_SANITIZER_ADDRESS=TRUE             \
+      -DENABLE_COVERAGE=ON                        \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON          \
+      -S.                                         \
+      -Bbuild                                     \
+ && cmake                                         \
+      --build build                               \
+      --config Debug                              \
+      --parallel                                  \
+ && cd tests && \
 	ctest -V && \
 	cd ${PRJ_ROOT} && \
 	mkdir build/graphviz && \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,39 +14,20 @@ add_library(
     FCHelpers.hpp
     IFCSqliteStorage.hpp)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(${PROJECT_NAME}_lib PRIVATE -Werror -Wall -Wextra)
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(${PROJECT_NAME}_lib PRIVATE -Wall -Wextra -Weverything -Wno-c++98-compat
-                                                       -Wno-c++98-compat-pedantic)
-endif()
-
-# sanitizer options if supported by compiler
-include(../cmake/Sanitizers.cmake)
-enable_sanitizers(project_options)
-
-# standard compiler warnings
-include(../cmake/CompilerWarnings.cmake)
-set_project_warnings(project_options)
-
-# allow for static analysis options
-include(../cmake/StaticAnalyzers.cmake)
-
-target_compile_features(${PROJECT_NAME}_lib PUBLIC cxx_std_17)
 target_link_libraries(
     ${PROJECT_NAME}_lib
-    PUBLIC acl
+    PUBLIC ${ZLIB_LIBRARIES}
+           acl
            cap
-           sqlite3
-           pthread
            dl
-           ${ZLIB_LIBRARIES}
            fmt::fmt
-           spdlog::spdlog)
-target_link_libraries(${PROJECT_NAME}_lib PRIVATE "stdc++fs")
+           project_options
+           pthread
+           spdlog::spdlog
+           sqlite3
+           stdc++fs)
+
 add_executable(${PROJECT_NAME} filcompare.cpp)
 target_include_directories(${PROJECT_NAME} PRIVATE submodules/SQLiteCpp/include/SQLiteCpp/)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_lib ${PROJECT_NAME}_own_sqlite_lib
-                                              ${PROJECT_NAME}_sqlitecpp_lib spdlog::spdlog)
-target_link_libraries(${PROJECT_NAME} PRIVATE project_options)
-target_link_libraries(${PROJECT_NAME} PRIVATE SQLiteCpp)
+                                              ${PROJECT_NAME}_sqlitecpp_lib spdlog::spdlog project_options SQLiteCpp)

--- a/src/sqlite_lib_own_implementation/CMakeLists.txt
+++ b/src/sqlite_lib_own_implementation/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_library(${PROJECT_NAME}_own_sqlite_lib FCSqliteIO.cpp FCSqliteIO.hpp FCSqliteLib.hpp)
-target_link_libraries(${PROJECT_NAME}_own_sqlite_lib PUBLIC fmt::fmt spdlog::spdlog)
+target_link_libraries(
+    ${PROJECT_NAME}_own_sqlite_lib
+    PRIVATE project_options
+    PUBLIC fmt::fmt spdlog::spdlog)

--- a/src/sqlitecpp_lib/CMakeLists.txt
+++ b/src/sqlitecpp_lib/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_library(${PROJECT_NAME}_sqlitecpp_lib FCSqliteCppImpl.cpp FCSqliteCppImpl.hpp)
-target_link_libraries(${PROJECT_NAME}_sqlitecpp_lib PUBLIC fmt::fmt spdlog::spdlog)
+target_link_libraries(
+    ${PROJECT_NAME}_sqlitecpp_lib
+    PRIVATE project_options SQLiteCpp
+    PUBLIC fmt::fmt spdlog::spdlog)

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -1,6 +1,14 @@
 set(LIB_NAME ${PROJECT_NAME}_submodules)
 add_subdirectory(googletest)
+
+set(SQLITECPP_RUN_CPPLINT
+    OFF
+    CACHE BOOL "Do not run cpplint for sqlitecpp")
+set(SQLITECPP_RUN_CPPCHECK
+    OFF
+    CACHE BOOL "Do not run cppcheck for sqlitecpp")
 add_subdirectory(SQLiteCpp)
+
 add_subdirectory(fmt EXCLUDE_FROM_ALL)
 
 set(SPDLOG_FMT_EXTERNAL_HO ON)


### PR DESCRIPTION
Properly link project_options interface lib so warnings are applied to the project.

The WARNINGS_AS_ERRORS setting had to be disabled as there are some warnings.

Related to issue #22 